### PR TITLE
[Cycode] Fix for vulnerable manifest file dependency - com.thoughtworks.xstream:xstream updated to version 1.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <webwolf.port>9090</webwolf.port>
     <wiremock.version>2.27.2</wiremock.version>
     <xml-resolver.version>1.2</xml-resolver.version>
-    <xstream.version>1.4.5</xstream.version>
+    <xstream.version>1.4.7</xstream.version>
     <!-- do not update necessary for lesson -->
     <zxcvbn.version>1.8.0</zxcvbn.version>
   </properties>


### PR DESCRIPTION
# Cycode Vulnerable Dependencies Update 
This pull request updates the following manifest file:

| File Path | Number of packages to update |
|---|---|
| `pom.xml` | 1 |

<details>
<summary><h3>:open_file_folder: pom.xml</h3></summary>

1 package will be updated to resolve vulnerabilities:

| Package Name | Current Version | Updated Version | 
|---|---|---|
| `com.thoughtworks.xstream:xstream` | 1.4.5 | 1.4.7 |
</details>
