### PR TITLE
[Cycode] Fix for vulnerable manifest file dependency - org.springframework.boot:spring-boot-starter-undertow updated to version 3.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-undertow</artifactId>
+      <version>3.5.10</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
# Cycode Vulnerable Dependencies Update 
This pull request updates the following manifest file:

| File Path | Number of packages to update |
|---|---|
| `pom.xml` | 1 |

<details>
<summary><h3>:open_file_folder: pom.xml</h3></summary>

1 package will be updated to resolve vulnerabilities:

| Package Name | Current Version | Updated Version | 
|---|---|---|
| `org.springframework.boot:spring-boot-starter-undertow` | 3.1.5 | 3.5.10 |
</details>
